### PR TITLE
fix: fixed the problem of multiple logins causing token errors caused by network problems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-
       - name: Get version
         id: version
         run: |

--- a/internal/handler/health_handler.go
+++ b/internal/handler/health_handler.go
@@ -10,7 +10,7 @@ import (
 
 func readinessHandler(c *gin.Context) {
 	if repository.GetDB() == nil {
-		response.JSONError(c, http.StatusInternalServerError, "Database not initialized")
+		response.JSONError(c, http.StatusInternalServerError, "", "Database not initialized")
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "message": "Application ready"})

--- a/internal/handler/sms_handler.go
+++ b/internal/handler/sms_handler.go
@@ -37,7 +37,7 @@ func (s *Server) SMSHandler(c *gin.Context) {
 		messageContent = c.PostForm("code")
 	} else {
 		log.Error(c, "unsupported Content-Type: %s", contentType)
-		response.JSONError(c, http.StatusUnsupportedMediaType, "unsupported Content-Type")
+		response.JSONError(c, http.StatusUnsupportedMediaType, "", "unsupported Content-Type")
 		return
 	}
 	if phoneNumber == "" || messageContent == "" {
@@ -49,7 +49,7 @@ func (s *Server) SMSHandler(c *gin.Context) {
 			errmsg += "Expected 'code' (from form) or 'content' (from JSON). "
 		}
 		log.Error(c, "Error: %s Received data: %v", errmsg, data)
-		response.JSONError(c, http.StatusBadRequest, errmsg)
+		response.JSONError(c, http.StatusBadRequest, "", errmsg)
 		return
 	}
 	SMSCfg := service.GetSMSCfg(nil)
@@ -61,21 +61,21 @@ func (s *Server) SMSHandler(c *gin.Context) {
 		if err != nil {
 			errmsg := fmt.Sprintf("Error getting sms code: %v", err)
 			log.Error(c, "Error: %s received data: %v", errmsg)
-			response.JSONError(c, http.StatusBadRequest, errmsg)
+			response.JSONError(c, http.StatusBadRequest, "", errmsg)
 			return
 		}
 		token, err := service.GetJWTToken(code, SMSCfg.ClientID, s.HTTPClient)
 		if err != nil {
 			errmsg := fmt.Sprintf("Error getting sms token: %v", err)
 			log.Error(c, "Error: %s Received data: %v", errmsg)
-			response.JSONError(c, http.StatusBadRequest, errmsg)
+			response.JSONError(c, http.StatusBadRequest, "", errmsg)
 			return
 		}
 		_, err = service.SendSMS(token, phoneNumber, messageContent)
 		if err != nil {
 			errmsg := fmt.Sprintf("Error getting sms token: %v", err)
 			log.Error(c, "Error: %s Received data: %v", errmsg)
-			response.JSONError(c, http.StatusBadRequest, errmsg)
+			response.JSONError(c, http.StatusBadRequest, "", errmsg)
 			return
 		}
 	}

--- a/internal/handler/token_handler.go
+++ b/internal/handler/token_handler.go
@@ -28,10 +28,14 @@ func tokenHandler(c *gin.Context) {
 		response.JSONError(c, http.StatusBadRequest, errs.ParmaNeedErr("machine_code or vscode_version").Error())
 		return
 	}
+	if query.State == "" {
+		response.JSONError(c, http.StatusBadRequest, errs.ParmaNeedErr("state").Error())
+		return
+	}
 	// if MachineCode is provided, get the token for the first time
 	// the account should have been pre-registered.
 	if query.MachineCode != "" {
-		tokenPair, code, err := firstGetToken(query.MachineCode, query.VscodeVersion)
+		tokenPair, code, err := firstGetToken(query.MachineCode, query.VscodeVersion, query.State)
 		if err != nil {
 			response.JSONError(c, code, err.Error())
 			return
@@ -68,7 +72,7 @@ func tokenHandler(c *gin.Context) {
 	})
 }
 
-func firstGetToken(machineCode, vscodeVersion string) (*utils.TokenPair, int, error) {
+func firstGetToken(machineCode, vscodeVersion, state string) (*utils.TokenPair, int, error) {
 	if vscodeVersion == "" {
 		return nil, http.StatusUnauthorized, errs.ParmaNeedErr("vscode_version")
 	}
@@ -78,6 +82,7 @@ func firstGetToken(machineCode, vscodeVersion string) (*utils.TokenPair, int, er
 	user, err := db.GetUserByDeviceConditions(ctx, map[string]any{
 		"machine_code":   machineCode,
 		"vscode_version": vscodeVersion,
+		"state":          state,
 		"status":         constants.LoginStatusLoggedOut,
 	})
 	if err != nil {

--- a/internal/providers/casdoor.go
+++ b/internal/providers/casdoor.go
@@ -297,7 +297,8 @@ func (s *CasdoorProvider) RefreshToken(ctx context.Context, refreshToken string)
 }
 
 func (s *CasdoorProvider) GetAuthURL(state, redirectURL string) string {
-	return s.config.BaseURL + constants.CasdoorAuthURI + "?client_id=" + s.config.ClientID + "&state=" + state + "&redirect_uri=" + redirectURL + "&response_type=code"
+	return s.config.BaseURL + constants.CasdoorAuthURI + "?client_id=" +
+		s.config.ClientID + "&state=" + state + "&redirect_uri=" + redirectURL + "&response_type=code"
 }
 
 func (s *CasdoorProvider) GetEndpoint(isInternal bool) string {

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -49,6 +49,7 @@ type Device struct {
 	MachineCode      string    `json:"machine_code"`
 	VSCodeVersion    string    `json:"vscode_version"`
 	PluginVersion    string    `json:"plugin_version"`
+	State            string    `json:"state"`
 	RefreshTokenHash string    `json:"refresh_token_hash"`
 	RefreshToken     string    `json:"refresh_token"`
 	AccessToken      string    `json:"access_token"`

--- a/pkg/errs/err.go
+++ b/pkg/errs/err.go
@@ -3,10 +3,22 @@ package errs
 import "errors"
 
 var (
-	ErrInvalidToken   = errors.New("invalid token, no related account exists")
-	ErrQueryUserInfo  = errors.New("query user info fail")
-	ErrUpdateUserInfo = errors.New("update user info fail")
-	ErrGenerateToken  = errors.New("generate token fail")
+	ErrInfoInvalidToken   = errors.New("invalid token, no related account exists")
+	ErrInfoQueryUserInfo  = errors.New("query user info fail")
+	ErrInfoUpdateUserInfo = errors.New("update user info fail")
+	ErrInfoGenerateToken  = errors.New("generate token fail")
+)
+
+const (
+	ErrBadRequestParma = "oidc-auth.badRequestParameter"
+	ErrDataEncryption  = "oidc-auth.loginEncryptFailed"
+	ErrDataDecryption  = "oidc-auth.LoginDecryptFailed"
+	ErrUserNotFound    = "oidc-auth.userNotFound"
+	ErrTokenInvalid    = "oidc-auth.tokenInvalid"
+	ErrUpdateInfo      = "oidc-auth.updateInfoFailed"
+	ErrBindAccount     = "oidc-auth.bindAccountFailed"
+	ErrTokenGenerate   = "oidc-auth.tokenGenerateFailed"
+	ErrAuthentication  = "oidc-auth.authenticationFailed"
 )
 
 func ParmaNeedErr(name string) error {

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -21,9 +21,10 @@ func JSONSuccess(c *gin.Context, message, data any) {
 }
 
 // JSONError returns error response (basic version)
-func JSONError(c *gin.Context, httpCode int, message string) {
+func JSONError(c *gin.Context, httpCode int, codeMsg, message string) {
+
 	c.JSON(httpCode, gin.H{
-		"code":      "",
+		"code":      codeMsg,
 		"success":   false,
 		"message":   message,
 		"timestamp": time.Now(),
@@ -31,7 +32,7 @@ func JSONError(c *gin.Context, httpCode int, message string) {
 	})
 }
 
-func HandleError(c *gin.Context, status int, err error) {
+func HandleError(c *gin.Context, status int, codeMsg string, err error) {
 	log.Error(nil, "operation failed: %v", err)
-	JSONError(c, status, err.Error())
+	JSONError(c, status, codeMsg, err.Error())
 }


### PR DESCRIPTION
Issue Description:
1. First Login Attempt: When the network connection is poor, the system continuously loops while attempting to acquire a token.
2. Second Login Attempt: When the network connection improves and a new login is initiated, the system successfully retrieves a new token. However, it still returns the token from the first login attempt.
3. Result: The front-end completes the second login, overwriting the token from the first attempt. As a result, the server-side (VS) can retrieve the token and proceed with the conversation. However, since the credit validation is performed against the database, the validation fails.